### PR TITLE
k8s: add helm chart to deploy OBA server and database

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,40 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.2.0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.7
+
+      - name: Install chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch main)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --validate-maintainers=false --target-branch main
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.10.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --target-branch main

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ The following icons are used to represent the status of support for each platfor
 - 🔲： not started
 
 1. Completed by Aaron, you can find Render deployment file here:  [onebusaway-docker](https://github.com/OneBusAway/onebusaway-docker), has been integrated into this repo.
-2. Completed by Neo2308, you can find `oba.yaml` here: [onebusaway-docker](https://github.com/OneBusAway/onebusaway-docker), will be rewrite in [Kustomize](https://github.com/kubernetes-sigs/kustomize).
+2. Completed by Neo2308, you can find `oba.yaml` here: [onebusaway-docker](https://github.com/OneBusAway/onebusaway-docker), has been rewritten in [Helm Charts](https://helm.sh/docs/topics/charts/).
 3. DigitalOcean app engine's gVisor is conflicting with supervisor, they already know this issue and will fix it in the future.

--- a/charts/onebusaway/.helmignore
+++ b/charts/onebusaway/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/onebusaway/Chart.yaml
+++ b/charts/onebusaway/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: onebusaway
+description: A Helm chart for OneBusAway
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/onebusaway/readme.md
+++ b/charts/onebusaway/readme.md
@@ -1,0 +1,49 @@
+# Kubernetes deployment guide
+
+1. Install Kubernetes components
+
+* Install Kubectl by following the instructions [here](https://kubernetes.io/docs/tasks/tools/). </br>
+* Install Helm by following the instructions [here](https://helm.sh/docs/intro/install/).</br>
+You should have the following output on your terminal:
+```bash
+$ kubectl version --client
+Client Version: v1.29.1
+Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
+
+$ helm version
+version.BuildInfo{Version:"v3.14.3", GitCommit:"f03cc04caaa8f6d7c3e67cf918929150cf6f3f12", GitTreeState:"clean", GoVersion:"go1.21.7"}
+```
+(Optional) Install k8s [lens](https://k8slens.dev/)  to manage your kubernetes cluster.
+
+2. Install Ingress Nginx
+
+RUN the following command to install Ingress Nginx:
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+
+helm repo update
+
+helm install nginx-ingress ingress-nginx/ingress-nginx
+```
+
+3. Configure your domain
+
+You should add a DNS record to your domain to point to the IP address of the Ingress Nginx controller. You can find the IP address by running:
+```bash
+kubectl get svc -n ingress-nginx
+```
+
+4. Configure the application
+
+Modify the `charts/values.yaml` file to configure the application. You can find the parameters meaning in [onebusaway-docker](https://github.com/OneBusAway/onebusaway-docker/#deployment-parameters).
+
+5. Deploy the application
+
+You can use this command to deploy the application:
+```bash
+helm install onebusaway charts/
+```
+Then you can check the status of the deployment by running:
+```bash
+kubectl get pods -n oba
+```

--- a/charts/onebusaway/templates/NOTES.txt
+++ b/charts/onebusaway/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- $host := .Values.ingress.host }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "charts.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "charts.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "charts.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "charts.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/onebusaway/templates/_helpers.tpl
+++ b/charts/onebusaway/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "charts.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "charts.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "charts.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "charts.labels" -}}
+helm.sh/chart: {{ include "charts.chart" . }}
+{{ include "charts.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "charts.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "charts.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "charts.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "charts.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/onebusaway/templates/configmap.yaml
+++ b/charts/onebusaway/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oba-configs
+  namespace: {{ .Values.namespace }}
+data:
+  GTFS_URL: "{{ .Values.config.GTFS_URL}}"

--- a/charts/onebusaway/templates/deployment-mysql.yaml
+++ b/charts/onebusaway/templates/deployment-mysql.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: oba-database
+  namespace: {{ .Values.namespace }}
+spec:
+  serviceName: "oba-database"
+  replicas: {{ .Values.replicas.database }}
+  selector:
+    matchLabels:
+      app: oba-database
+  template:
+    metadata:
+      labels:
+        app: oba-database
+    spec:
+      containers:
+        - name: oba-database
+          image: {{ .Values.image.mysql.repository }}:{{ .Values.image.mysql.tag }}
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oba-secrets
+                  key: MYSQL_ROOT_PASSWORD
+            - name: MYSQL_DATABASE
+              value: oba_database
+            - name: MYSQL_USER
+              value: oba_user
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oba-secrets
+                  key: MYSQL_PASSWORD
+          ports:
+            - containerPort: 3306
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+          livenessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - "-h"
+                - "127.0.0.1"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - "-h"
+                - "127.0.0.1"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi

--- a/charts/onebusaway/templates/deployment.yaml
+++ b/charts/onebusaway/templates/deployment.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oba-app-deployment
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.replicas.app }}
+  selector:
+    matchLabels:
+      app: oba-app
+  template:
+    metadata:
+      labels:
+        app: oba-app
+    spec:
+      initContainers:
+        - name: oba-bundler
+          image: {{ .Values.image.oba.bundler.repository }}:{{ .Values.image.oba.bundler.tag }}
+          env:
+            - name: GTFS_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: oba-configs
+                  key: GTFS_URL
+          volumeMounts:
+            - mountPath: /bundle
+              name: bundle-volume
+      containers:
+        - name: oba-app
+          image: {{ .Values.image.oba.app.repository }}:{{ .Values.image.oba.app.tag }}
+          env:
+            - name: JDBC_URL
+              value: jdbc:mysql://oba-database.{{ .Values.namespace }}.svc.cluster.local:3306/oba_database
+            - name: JDBC_USER
+              value: oba_user
+            - name: JDBC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oba-secrets
+                  key: JDBC_PASSWORD
+            - name: GTFS_URL
+              value: {{ .Values.env.GTFS_URL }}
+            - name: TEST_API_KEY
+              value: {{ .Values.env.TEST_API_KEY }}
+            - name: VEHICLE_POSITIONS_URL
+              value: {{ .Values.env.VEHICLE_POSITIONS_URL }}
+            - name: TRIP_UPDATES_URL
+              value: {{ .Values.env.TRIP_UPDATES_URL }}
+            - name: ALERTS_URL
+              value: {{ .Values.env.ALERTS_URL }}
+            - name: REFRESH_INTERVAL
+              value: "{{ .Values.env.REFRESH_INTERVAL }}"
+            - name: AGENCY_ID
+              value: {{ .Values.env.AGENCY_ID }}
+            - name: TZ
+              value: {{ .Values.env.TZ }}
+            - name: GOOGLE_MAPS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: oba-secrets
+                  key: GOOGLE_MAPS_API_KEY
+            - name: GOOGLE_MAPS_CHANNEL_ID
+              value: {{ .Values.env.GOOGLE_MAPS_CHANNEL_ID }}
+            - name: GOOGLE_MAPS_CLIENT_ID
+              value: {{ .Values.env.GOOGLE_MAPS_CLIENT_ID }}
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - mountPath: /bundle
+              name: bundle-volume
+          livenessProbe:
+            httpGet:
+              path: /onebusaway-api-webapp/api/where/current-time.json?key=org.onebusaway.iphone
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /onebusaway-api-webapp/api/where/current-time.json?key=org.onebusaway.iphone
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+      volumes:
+        - name: bundle-volume
+          emptyDir: {}

--- a/charts/onebusaway/templates/hpa.yaml
+++ b/charts/onebusaway/templates/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: oba-app-hpa
+  namespace: {{ .Values.namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: oba-app-deployment
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.cpuUtilizationPercentage }}

--- a/charts/onebusaway/templates/ingress.yaml
+++ b/charts/onebusaway/templates/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oba-app-ingress
+  namespace: {{ .Values.namespace }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: oba-app
+                port:
+                  number: 8080
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecret }}
+  {{- end }}

--- a/charts/onebusaway/templates/namespace.yaml
+++ b/charts/onebusaway/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}

--- a/charts/onebusaway/templates/secret.yaml
+++ b/charts/onebusaway/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oba-secrets
+  namespace: {{ .Values.namespace }}
+type: Opaque
+data:
+  MYSQL_ROOT_PASSWORD: {{ .Values.secrets.MYSQL_ROOT_PASSWORD | quote }}
+  MYSQL_PASSWORD: {{ .Values.secrets.MYSQL_PASSWORD | quote }}
+  JDBC_PASSWORD: {{ .Values.secrets.JDBC_PASSWORD | quote }}
+  GOOGLE_MAPS_API_KEY: {{ .Values.secrets.GOOGLE_MAPS_API_KEY | quote }}

--- a/charts/onebusaway/templates/service.yaml
+++ b/charts/onebusaway/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oba-database
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: oba-database
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306

--- a/charts/onebusaway/values.yaml
+++ b/charts/onebusaway/values.yaml
@@ -1,0 +1,50 @@
+namespace: oba
+
+image:
+  mysql:
+    repository: mysql
+    tag: "8.3"
+  oba:
+    app:
+      repository: opentransitsoftwarefoundation/onebusaway-api-webapp
+      tag: "2.5.12-cs-v1.0.0"
+    bundler:
+      repository: opentransitsoftwarefoundation/onebusaway-bundle-builder
+      tag: "2.5.12-cs-v1.0.0"
+
+replicas:
+  database: 1
+  app: 1
+
+secrets:
+  MYSQL_ROOT_PASSWORD: "SW5zM2N1cmUh"
+  MYSQL_PASSWORD: "b2JhX3Bhc3N3b3Jk"
+  JDBC_PASSWORD: "b2JhX3Bhc3N3b3Jk"
+  GOOGLE_MAPS_API_KEY: ""
+
+config:
+  GTFS_URL: "https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip"
+
+hpa:
+  minReplicas: 1
+  maxReplicas: 3
+  cpuUtilizationPercentage: 80
+
+ingress:
+  enabled: true
+  host: example.oba.com
+  annotations: {}
+  tls: false
+  tlsSecret: ""
+
+env:
+  GTFS_URL: "https://opendata.burlington.ca/gtfs-rt/GTFS_Data.zip"
+  TEST_API_KEY: "test"
+  VEHICLE_POSITIONS_URL: "https://opendata.burlington.ca/gtfs-rt/GTFS_VehiclePositions.pb"
+  TRIP_UPDATES_URL: "https://opendata.burlington.ca/gtfs-rt/GTFS_TripUpdates.pb"
+  ALERTS_URL: "https://opendata.burlington.ca/gtfs-rt/GTFS_ServiceAlerts.pb"
+  REFRESH_INTERVAL: 30
+  AGENCY_ID: "Burlington"
+  TZ: "America/Toronto"
+  GOOGLE_MAPS_CHANNEL_ID: ""
+  GOOGLE_MAPS_CLIENT_ID: ""

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,4 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+chart-dirs:
+  - charts


### PR DESCRIPTION
Add a Helm chart to deploy the OBA server and database to Kubernetes. A workflow is also included to ensure everything works seamlessly.