### PR TITLE
chore: increase the threshold of health check

### DIFF
--- a/charts/onebusaway/templates/deployment.yaml
+++ b/charts/onebusaway/templates/deployment.yaml
@@ -76,15 +76,15 @@ spec:
             httpGet:
               path: /onebusaway-api-webapp/api/where/current-time.json?key=org.onebusaway.iphone
               port: 8080
-            initialDelaySeconds: 60
-            periodSeconds: 30
+            initialDelaySeconds: 120
+            periodSeconds: 60
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /onebusaway-api-webapp/api/where/current-time.json?key=org.onebusaway.iphone
               port: 8080
-            initialDelaySeconds: 60
-            periodSeconds: 30
+            initialDelaySeconds: 120
+            periodSeconds: 60
             failureThreshold: 3
       volumes:
         - name: bundle-volume


### PR DESCRIPTION
Extend the healthcheck timeout to allow the OBA server to complete deployment.